### PR TITLE
Refactor: Make DelegateInvestorManagementInternal and KeyringInvestorManagementInternal abstract classes

### DIFF
--- a/src/register/delegateInvestors/DelegateInvestorManagementInternal.sol
+++ b/src/register/delegateInvestors/DelegateInvestorManagementInternal.sol
@@ -8,7 +8,7 @@ import {InvestorManagementInternal} from "../investors/InvestorManagementInterna
 import {DelegateInvestorManagementStorage} from "./DelegateInvestorManagementStorage.sol";
 import {IDelegateInvestorManagementInternal} from "./IDelegateInvestorManagementInternal.sol";
 
-contract DelegateInvestorManagementInternal is
+abstract contract DelegateInvestorManagementInternal is
     IDelegateInvestorManagementInternal,
     InvestorManagementInternal
 {

--- a/src/register/keyring/KeyringInvestorManagementInternal.sol
+++ b/src/register/keyring/KeyringInvestorManagementInternal.sol
@@ -12,7 +12,7 @@ interface IKeyringAdapter {
     function checkCredential(uint256 policyId, address account) external view returns (bool);
 }
 
-contract KeyringInvestorManagementInternal is
+abstract contract KeyringInvestorManagementInternal is
     IKeyringInvestorManagementInternal,
     RegisterRoleManagementInternal
 {


### PR DESCRIPTION
Changes included:

- Updated DelegateInvestorManagementInternal class to abstract.
- Updated KeyringInvestorManagementInternal class to abstract.

Reason for the change:

- These classes are intended to act as base classes and should not be instantiated directly.
- Marking them as abstract aligns with their intended use as parent classes providing core logic to derived contracts.

Impact:

- Any contracts or classes inheriting from these two will need to implement any missing abstract functions.
- This change improves code clarity by clearly defining which classes are intended to be instantiated and which are not.
