### PR TITLE
Change _totalSupplyAtCoupon visibility from public to internal

### DIFF
--- a/src/register/snapshot/CouponSnapshotManagementInternal.sol
+++ b/src/register/snapshot/CouponSnapshotManagementInternal.sol
@@ -61,7 +61,7 @@ abstract contract CouponSnapshotManagementInternal is
      */
     function _totalSupplyAtCoupon(
         uint256 _couponDate
-    ) public view virtual returns (uint256) {
+    ) internal view virtual returns (uint256) {
         CouponSnapshotManagementStorage.Layout
             storage l = CouponSnapshotManagementStorage.layout();
         uint256 snapshotId = l.couponDateSnapshotId[_couponDate];


### PR DESCRIPTION
This PR updates the visibility of the _totalSupplyAtCoupon function from public to internal.

Changes:

-  Modified the function signature of _totalSupplyAtCoupon to be internal instead of public.
-  Ensures the function remains accessible within the contract or its inheriting contracts, promoting encapsulation and reducing unnecessary external visibility.

Reason for Change:

- Security: Limiting access to internal use to prevent external access where not needed.
- Encapsulation: Follows best practices for smart contract design by exposing only required interfaces.